### PR TITLE
More maps double sided redesign

### DIFF
--- a/blender/LilySurfaceScrapper/CyclesMaterialData.py
+++ b/blender/LilySurfaceScrapper/CyclesMaterialData.py
@@ -6,7 +6,6 @@
 
 import bpy
 from bpy_extras.node_shader_utils import PrincipledBSDFWrapper
-
 from .MaterialData import MaterialData
 from .cycles_utils import getCyclesImage, autoAlignNodes
 
@@ -40,58 +39,40 @@ class CyclesMaterialData(MaterialData):
         links = mat.node_tree.links
         principled_mat = PrincipledBSDFWrapper(mat, is_readonly=False)
         principled = principled_mat.node_principled_bsdf
-        back_principled = None
         mat_output = principled_mat.node_out
         principled_mat.roughness = 1.0
-        normal_node = None
-        displacement_node = None
+        front = {}
+        back = {}
 
+        # Create all of the texture nodes
         for map_name, img in self.maps.items():
             if img is None or map_name.split("_")[0] not in __class__.input_tr:
                 continue
-
-            current_principled = principled
-            if map_name.endswith("_back"):
-                if back_principled is None:
-                    # Create backface principled and connect it
-                    back_principled = nodes.new(type="ShaderNodeBsdfPrincipled")
-                    geometry_node = nodes.new(type="ShaderNodeNewGeometry")
-                    mix_node = nodes.new(type="ShaderNodeMixShader")
-                    back_principled.inputs["Roughness"].default_value = 1.0
-                    links.new(geometry_node.outputs["Backfacing"], mix_node.inputs[0])
-                    links.new(principled.outputs[0], mix_node.inputs[1])
-                    links.new(back_principled.outputs[0], mix_node.inputs[2])
-                    links.new(mix_node.outputs[0], mat_output.inputs[0])
-                current_principled = back_principled
-                map_name = map_name[:-5]  # remove "_back"
-                
+            
             texture_node = nodes.new(type="ShaderNodeTexImage")
+            if "_back" in map_name:
+                map_name = map_name[:-5] # remove "_back"
+                back[map_name] = texture_node
+            else:
+                front[map_name] = texture_node
+            
             texture_node.image = getCyclesImage(img)
             texture_node.image.colorspace_settings.name = "sRGB" if map_name == "baseColor" else "Non-Color"
-
             if hasattr(texture_node, "color_space"):
                 texture_node.color_space = "COLOR" if map_name == "baseColor" else "NONE"
-            elif map_name == "glossiness":
-                invert_node = nodes.new(type="ShaderNodeInvert")
-                links.new(texture_node.outputs["Color"], invert_node.inputs["Color"])
-                links.new(invert_node.outputs["Color"], current_principled.inputs["Roughness"])
-                current_principled
-            elif map_name == "height":
-                displacement_node = nodes.new(type="ShaderNodeDisplacement")
-                links.new(texture_node.outputs["Color"], displacement_node.inputs["Height"])
-                links.new(displacement_node.outputs["Displacement"], mat_output.inputs[2])
-            elif map_name == "normal":
-                normal_node = nodes.new(type="ShaderNodeNormalMap")
-                links.new(texture_node.outputs["Color"], normal_node.inputs["Color"])
-                links.new(normal_node.outputs["Normal"], current_principled.inputs["Normal"])
-            else:
-                links.new(texture_node.outputs["Color"], current_principled.inputs[__class__.input_tr[map_name]])
-
             if map_name == "opacity":
                 mat.blend_method = 'BLEND'
-            
-            if displacement_node is not None and normal_node is not None:
-                    links.new(normal_node.outputs["Normal"], displacement_node.inputs["Normal"])
+        
+        if not back: # If there is no item in the back dictionary
+            (links.new(node.outputs["Color"], principled.inputs[__class__.input_tr[name]]) for name, node in front.items()) # Wire up all of the nodes traditionally
+        else:
+            geometry_node = nodes.new("ShaderNodeNewGeometry")
+            def setup(name, front, back, mix):
+                links.new(geometry_node.outputs["Backfacing"], mix.inputs[0])
+                links.new(front.outputs["Color"], mix.inputs[1])
+                links.new(back.outputs["Color"], mix.inputs[2])
+                links.new(mix.outputs["Color"], principled.inputs[__class__.input_tr[name]])
+            (setup(name, node, back[name], nodes.new(type="ShaderNodeMixRGB")) for name, node in front.items() if back.get(name))
 
         autoAlignNodes(mat_output)
 

--- a/blender/LilySurfaceScrapper/CyclesMaterialData.py
+++ b/blender/LilySurfaceScrapper/CyclesMaterialData.py
@@ -13,12 +13,12 @@ class CyclesMaterialData(MaterialData):
     # Translate our internal map names into cycles principled inputs
     input_tr = {
         'baseColor': 'Base Color',
-        'normal': 'Normal',
         'roughness': 'Roughness',
         'metallic': 'Metallic',
         'specular': 'Specular',
         'opacity': 'Alpha',
         'emission': 'Emission',
+        'normal': '',
         'height': '',
         'ambientOcclusion': '', # https://github.com/KhronosGroup/glTF-Blender-IO/issues/123
         'glossiness': '',
@@ -64,23 +64,41 @@ class CyclesMaterialData(MaterialData):
                 mat.blend_method = 'BLEND'
 
         front = back if not front else front # In case just the backside texture was chosen
-        
-        # Wire up all of the nodes traditionally
+
+        def advanced_setup(name, node):
+            if name == "glossiness":
+                invert_node = nodes.new(type="ShaderNodeInvert")
+                links.new(node.outputs["Color"], invert_node.inputs["Color"])
+                links.new(invert_node.outputs["Color"], principled.inputs["Roughness"])
+            elif name == "height":
+                displacement_node = nodes.new(type="ShaderNodeDisplacement")
+                links.new(node.outputs["Color"], displacement_node.inputs["Height"])
+                links.new(displacement_node.outputs["Displacement"], mat_output.inputs[2])
+            elif name == "normal":
+                normal_node = nodes.new(type="ShaderNodeNormalMap")
+                links.new(node.outputs["Color"], normal_node.inputs["Color"])
+                links.new(normal_node.outputs["Normal"], principled.inputs["Normal"])
+
         if not back: # If there is no item in the back dictionary
             for name, node in front.items():
                 if __class__.input_tr.get(name):
                     links.new(node.outputs["Color"], principled.inputs[__class__.input_tr[name]])
+                else:
+                    advanced_setup(name, node)
         else:
             geometry_node = nodes.new("ShaderNodeNewGeometry")
             def setup(name, front, back, mix):
                 links.new(geometry_node.outputs["Backfacing"], mix.inputs[0])
                 links.new(front.outputs["Color"], mix.inputs[1])
                 links.new(back.outputs["Color"], mix.inputs[2])
-                links.new(mix.outputs["Color"], principled.inputs[__class__.input_tr[name]])
+                if __class__.input_tr.get(name):
+                    links.new(mix.outputs["Color"], principled.inputs[__class__.input_tr[name]])
+                else:
+                    advanced_setup(name, mix)
             for name, node in front.items():
-                if back.get(name) and __class__.input_tr.get(name):
+                if back.get(name):
                     setup(name, node, back[name], nodes.new(type="ShaderNodeMixRGB"))
-
+        
         autoAlignNodes(mat_output)
 
         return mat


### PR DESCRIPTION
This branch is for working out the redesigned process of creating the cycles node tree (moving from 2 principled shaders to one principled shader with multiple mix RGB nodes for switching the textures)

Currently it doesn't support normals, glossiness and displacement. But this is to be changed once I get it actually working.